### PR TITLE
Feature/schedule parser errors print

### DIFF
--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -24,6 +24,7 @@ const newsSlider = ref([])
 const newsDisabler = ref([])
 const currNews = ref([])
 const scheduleUrl = ref(null)
+const scheduleError = ref('')
 const userList = ref([])
 const sortOption = ref('1');
 const filterOption = ref('');
@@ -351,35 +352,46 @@ const deleteNews = async (artId, index) => {
 }
 
 const uploadSchedule = async () => {
+  scheduleError.value = ''
+
+  if (!scheduleUrl.value?.files?.length) {
+    scheduleError.value = 'Выберите файл для загрузки'
+    return
+  }
+
   let formData = new FormData()
   isLoading.value = true
 
   formData.append('file', scheduleUrl.value.files[0])
 
-  await parserAxios.post('lessons/parse/',
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data'
-        }
-      })
-      .then(() => {
-        location.replace('/is/full-schedule')
-      })
-  // .then(async (schData) => {
-  //     let parseData = new FormData()
-  //
-  //     parseData.append('filepath', schData.data)
-  //
-  //     await axios.post('parser/lessons/parse/', parseData, {
-  //         headers: {
-  //             'Content-Type': 'multipart/form-data'
-  //         }
-  //     })
-  //         .then(() => {
-  //           isLoading.value = false
-  //         })
-  // })
+  try {
+    const response = await parserAxios.post('lessons/parse/',
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
+        })
+
+    if (response.data?.errors?.length) {
+      sessionStorage.setItem('scheduleParseErrors', JSON.stringify(response.data.errors))
+    }
+
+    location.replace('/is/full-schedule')
+  } catch (err) {
+    const status = err.response?.status
+    const errorType = err.response?.data?.error?.type
+
+    if (status === 400) {
+      scheduleError.value = 'Файл не передан или имеет неверный формат'
+    } else if (status === 500 || errorType === 'critical_error') {
+      scheduleError.value = 'Не удалось обработать файл. Убедитесь, что загружаемый файл — корректный .xlsx'
+    } else {
+      scheduleError.value = 'Произошла ошибка при загрузке расписания'
+    }
+  } finally {
+    isLoading.value = false
+  }
 }
 
 const getUsers = async () => {
@@ -626,8 +638,11 @@ const deleteMail = async (mailId) => {
       </div>
       <div v-show="activeItem === 'schedule'" class="admin__view-item">
         <div class="admin-schedule">
-          <input ref="scheduleUrl" type="file">
+          <input ref="scheduleUrl" type="file" accept=".xlsx">
           <button @click="uploadSchedule" class="admin-button">Загрузить</button>
+        </div>
+        <div v-if="scheduleError" class="schedule-error">
+          {{ scheduleError }}
         </div>
       </div>
       <div v-show="admRole === 'ADMIN' && activeItem === 'employees'" class="admin__view-item">
@@ -1016,6 +1031,16 @@ const deleteMail = async (mailId) => {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.schedule-error {
+  margin-top: 10px;
+  padding: 12px 16px;
+  background-color: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c6cb;
+  border-radius: 6px;
+  font-size: 14px;
 }
 
 .new-view {

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -455,8 +455,8 @@ const deleteMail = async (mailId) => {
               <label v-if="!checkDisable[index]" class="slider-admin__box-label" :for="slide.id"></label>
               <svg v-if="!checkDisable[index]" width="64px" height="64px" viewBox="0 0 24 24"
                    xmlns="http://www.w3.org/2000/svg">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier">
                   <path fill-rule="evenodd" clip-rule="evenodd"
                         d="M21.1213 2.70705C19.9497 1.53548 18.0503 1.53547 16.8787 2.70705L15.1989 4.38685L7.29289 12.2928C7.16473 12.421 7.07382 12.5816 7.02986 12.7574L6.02986 16.7574C5.94466 17.0982 6.04451 17.4587 6.29289 17.707C6.54127 17.9554 6.90176 18.0553 7.24254 17.9701L11.2425 16.9701C11.4184 16.9261 11.5789 16.8352 11.7071 16.707L19.5556 8.85857L21.2929 7.12126C22.4645 5.94969 22.4645 4.05019 21.2929 2.87862L21.1213 2.70705ZM18.2929 4.12126C18.6834 3.73074 19.3166 3.73074 19.7071 4.12126L19.8787 4.29283C20.2692 4.68336 20.2692 5.31653 19.8787 5.70705L18.8622 6.72357L17.3068 5.10738L18.2929 4.12126ZM15.8923 6.52185L17.4477 8.13804L10.4888 15.097L8.37437 15.6256L8.90296 13.5112L15.8923 6.52185ZM4 7.99994C4 7.44766 4.44772 6.99994 5 6.99994H10C10.5523 6.99994 11 6.55223 11 5.99994C11 5.44766 10.5523 4.99994 10 4.99994H5C3.34315 4.99994 2 6.34309 2 7.99994V18.9999C2 20.6568 3.34315 21.9999 5 21.9999H16C17.6569 21.9999 19 20.6568 19 18.9999V13.9999C19 13.4477 18.5523 12.9999 18 12.9999C17.4477 12.9999 17 13.4477 17 13.9999V18.9999C17 19.5522 16.5523 19.9999 16 19.9999H5C4.44772 19.9999 4 19.5522 4 18.9999V7.99994Z"></path>
@@ -471,22 +471,22 @@ const deleteMail = async (mailId) => {
             <div class="slider-admin__item-buttons">
               <svg @click="checkDisable[index] = false" width="64px" height="64px" viewBox="0 0 24 24"
                    xmlns="http://www.w3.org/2000/svg">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier">
                   <path fill-rule="evenodd" clip-rule="evenodd"
                         d="M21.1213 2.70705C19.9497 1.53548 18.0503 1.53547 16.8787 2.70705L15.1989 4.38685L7.29289 12.2928C7.16473 12.421 7.07382 12.5816 7.02986 12.7574L6.02986 16.7574C5.94466 17.0982 6.04451 17.4587 6.29289 17.707C6.54127 17.9554 6.90176 18.0553 7.24254 17.9701L11.2425 16.9701C11.4184 16.9261 11.5789 16.8352 11.7071 16.707L19.5556 8.85857L21.2929 7.12126C22.4645 5.94969 22.4645 4.05019 21.2929 2.87862L21.1213 2.70705ZM18.2929 4.12126C18.6834 3.73074 19.3166 3.73074 19.7071 4.12126L19.8787 4.29283C20.2692 4.68336 20.2692 5.31653 19.8787 5.70705L18.8622 6.72357L17.3068 5.10738L18.2929 4.12126ZM15.8923 6.52185L17.4477 8.13804L10.4888 15.097L8.37437 15.6256L8.90296 13.5112L15.8923 6.52185ZM4 7.99994C4 7.44766 4.44772 6.99994 5 6.99994H10C10.5523 6.99994 11 6.55223 11 5.99994C11 5.44766 10.5523 4.99994 10 4.99994H5C3.34315 4.99994 2 6.34309 2 7.99994V18.9999C2 20.6568 3.34315 21.9999 5 21.9999H16C17.6569 21.9999 19 20.6568 19 18.9999V13.9999C19 13.4477 18.5523 12.9999 18 12.9999C17.4477 12.9999 17 13.4477 17 13.9999V18.9999C17 19.5522 16.5523 19.9999 16 19.9999H5C4.44772 19.9999 4 19.5522 4 18.9999V7.99994Z"></path>
                 </g>
               </svg>
-              <svg @click="deleteSlide(slide.id)" width="64px" height="64px" viewBox="0 -0.5 21 21" version="1.1"
-                   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="#000000">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+              <svg @click="deleteSlide(slide.id)" width="64px" height="64px" viewBox="0 -0.5 21 21"
+                   xmlns="http://www.w3.org/2000/svg" style="fill:#000000">
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier"><title>delete [#1487]</title>
                   <desc>Created with Sketch.</desc>
                   <defs></defs>
-                  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                    <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" fill="#00295F">
+                  <g id="Page-1" style="stroke:none;stroke-width:1;fill:none;fill-rule:evenodd">
+                    <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" style="fill:#00295F">
                       <g id="icons" transform="translate(56.000000, 160.000000)">
                         <path
                             d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z"
@@ -504,14 +504,14 @@ const deleteMail = async (mailId) => {
           </div>
           <div v-if="newSlide" class="slider-admin__item">
             <div class="slider-admin__box">
-              <img v-if="newFile === null" alt="" class="slider-admin__item-img">
+              <div v-if="newFile === null" class="slider-admin__item-img"></div>
               <img v-else :src="`${newFile}`" alt="" class="slider-admin__item-img">
               <input v-on:change="checkNewFile" ref="addUrl" id="new-slide" type="file"
                      accept="image/png, image/jpeg, image/jpg" class="slider-admin__box-input">
               <label for="new-slide" class="slider-admin__box-label"></label>
               <svg width="64px" height="64px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier">
                   <path fill-rule="evenodd" clip-rule="evenodd"
                         d="M21.1213 2.70705C19.9497 1.53548 18.0503 1.53547 16.8787 2.70705L15.1989 4.38685L7.29289 12.2928C7.16473 12.421 7.07382 12.5816 7.02986 12.7574L6.02986 16.7574C5.94466 17.0982 6.04451 17.4587 6.29289 17.707C6.54127 17.9554 6.90176 18.0553 7.24254 17.9701L11.2425 16.9701C11.4184 16.9261 11.5789 16.8352 11.7071 16.707L19.5556 8.85857L21.2929 7.12126C22.4645 5.94969 22.4645 4.05019 21.2929 2.87862L21.1213 2.70705ZM18.2929 4.12126C18.6834 3.73074 19.3166 3.73074 19.7071 4.12126L19.8787 4.29283C20.2692 4.68336 20.2692 5.31653 19.8787 5.70705L18.8622 6.72357L17.3068 5.10738L18.2929 4.12126ZM15.8923 6.52185L17.4477 8.13804L10.4888 15.097L8.37437 15.6256L8.90296 13.5112L15.8923 6.52185ZM4 7.99994C4 7.44766 4.44772 6.99994 5 6.99994H10C10.5523 6.99994 11 6.55223 11 5.99994C11 5.44766 10.5523 4.99994 10 4.99994H5C3.34315 4.99994 2 6.34309 2 7.99994V18.9999C2 20.6568 3.34315 21.9999 5 21.9999H16C17.6569 21.9999 19 20.6568 19 18.9999V13.9999C19 13.4477 18.5523 12.9999 18 12.9999C17.4477 12.9999 17 13.4477 17 13.9999V18.9999C17 19.5522 16.5523 19.9999 16 19.9999H5C4.44772 19.9999 4 19.5522 4 18.9999V7.99994Z"></path>
@@ -539,16 +539,15 @@ const deleteMail = async (mailId) => {
                 </div>
                 <p class="event__name">{{ event.title }}</p>
               </router-link>
-              <svg style="margin-left: 20px; cursor:pointer;" @click="deleteEvent(event.id, index)" width="32" height="32"
-                   viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg"
-                   xmlns:xlink="http://www.w3.org/1999/xlink" fill="#000000">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+              <svg style="margin-left: 20px; cursor:pointer; fill:#000000" @click="deleteEvent(event.id, index)" width="32" height="32"
+                   viewBox="0 -0.5 21 21" xmlns="http://www.w3.org/2000/svg">
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier"><title>delete [#1487]</title>
                   <desc>Created with Sketch.</desc>
                   <defs></defs>
-                  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                    <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" fill="#00295F">
+                  <g id="Page-1" style="stroke:none;stroke-width:1;fill:none;fill-rule:evenodd">
+                    <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" style="fill:#00295F">
                       <g id="icons" transform="translate(56.000000, 160.000000)">
                         <path
                             d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z"
@@ -575,8 +574,8 @@ const deleteMail = async (mailId) => {
               <label v-if="newsDisabler[index]" class="slider-admin__box-label" :for="newsSlide.id"></label>
               <svg v-if="newsDisabler[index]" width="64px" height="64px" viewBox="0 0 24 24"
                    xmlns="http://www.w3.org/2000/svg">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier">
                   <path fill-rule="evenodd" clip-rule="evenodd"
                         d="M21.1213 2.70705C19.9497 1.53548 18.0503 1.53547 16.8787 2.70705L15.1989 4.38685L7.29289 12.2928C7.16473 12.421 7.07382 12.5816 7.02986 12.7574L6.02986 16.7574C5.94466 17.0982 6.04451 17.4587 6.29289 17.707C6.54127 17.9554 6.90176 18.0553 7.24254 17.9701L11.2425 16.9701C11.4184 16.9261 11.5789 16.8352 11.7071 16.707L19.5556 8.85857L21.2929 7.12126C22.4645 5.94969 22.4645 4.05019 21.2929 2.87862L21.1213 2.70705ZM18.2929 4.12126C18.6834 3.73074 19.3166 3.73074 19.7071 4.12126L19.8787 4.29283C20.2692 4.68336 20.2692 5.31653 19.8787 5.70705L18.8622 6.72357L17.3068 5.10738L18.2929 4.12126ZM15.8923 6.52185L17.4477 8.13804L10.4888 15.097L8.37437 15.6256L8.90296 13.5112L15.8923 6.52185ZM4 7.99994C4 7.44766 4.44772 6.99994 5 6.99994H10C10.5523 6.99994 11 6.55223 11 5.99994C11 5.44766 10.5523 4.99994 10 4.99994H5C3.34315 4.99994 2 6.34309 2 7.99994V18.9999C2 20.6568 3.34315 21.9999 5 21.9999H16C17.6569 21.9999 19 20.6568 19 18.9999V13.9999C19 13.4477 18.5523 12.9999 18 12.9999C17.4477 12.9999 17 13.4477 17 13.9999V18.9999C17 19.5522 16.5523 19.9999 16 19.9999H5C4.44772 19.9999 4 19.5522 4 18.9999V7.99994Z"></path>
@@ -590,23 +589,22 @@ const deleteMail = async (mailId) => {
                       :disabled="!newsDisabler[index]"></textarea>
             <div class="news-admin__buttons">
               <svg @click="newsDisabler[index] = true" width="30" height="30" viewBox="0 0 24 24"
-                   xmlns="http://www.w3.org/2000/svg" fill="#00295F">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                   xmlns="http://www.w3.org/2000/svg" style="fill:#00295F">
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier">
                   <path fill-rule="evenodd" clip-rule="evenodd"
                         d="M21.1213 2.70705C19.9497 1.53548 18.0503 1.53547 16.8787 2.70705L15.1989 4.38685L7.29289 12.2928C7.16473 12.421 7.07382 12.5816 7.02986 12.7574L6.02986 16.7574C5.94466 17.0982 6.04451 17.4587 6.29289 17.707C6.54127 17.9554 6.90176 18.0553 7.24254 17.9701L11.2425 16.9701C11.4184 16.9261 11.5789 16.8352 11.7071 16.707L19.5556 8.85857L21.2929 7.12126C22.4645 5.94969 22.4645 4.05019 21.2929 2.87862L21.1213 2.70705ZM18.2929 4.12126C18.6834 3.73074 19.3166 3.73074 19.7071 4.12126L19.8787 4.29283C20.2692 4.68336 20.2692 5.31653 19.8787 5.70705L18.8622 6.72357L17.3068 5.10738L18.2929 4.12126ZM15.8923 6.52185L17.4477 8.13804L10.4888 15.097L8.37437 15.6256L8.90296 13.5112L15.8923 6.52185ZM4 7.99994C4 7.44766 4.44772 6.99994 5 6.99994H10C10.5523 6.99994 11 6.55223 11 5.99994C11 5.44766 10.5523 4.99994 10 4.99994H5C3.34315 4.99994 2 6.34309 2 7.99994V18.9999C2 20.6568 3.34315 21.9999 5 21.9999H16C17.6569 21.9999 19 20.6568 19 18.9999V13.9999C19 13.4477 18.5523 12.9999 18 12.9999C17.4477 12.9999 17 13.4477 17 13.9999V18.9999C17 19.5522 16.5523 19.9999 16 19.9999H5C4.44772 19.9999 4 19.5522 4 18.9999V7.99994Z"></path>
                 </g>
               </svg>
-              <svg @click="deleteNews(newsSlide.id, index)" width="30" height="30" viewBox="0 -0.5 21 21" version="1.1"
-                   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="#000000">
-                <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+              <svg @click="deleteNews(newsSlide.id, index)" width="30" height="30" viewBox="0 -0.5 21 21" xmlns="http://www.w3.org/2000/svg" style="fill:#000000">
+                <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                 <g id="SVGRepo_iconCarrier"><title>delete [#1487]</title>
                   <desc>Created with Sketch.</desc>
                   <defs></defs>
-                  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                    <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" fill="#00295F">
+                  <g id="Page-1" style="stroke:none;stroke-width:1;fill:none;fill-rule:evenodd">
+                    <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" style="fill:#00295F">
                       <g id="icons" transform="translate(56.000000, 160.000000)">
                         <path
                             d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z"
@@ -617,10 +615,9 @@ const deleteMail = async (mailId) => {
                 </g>
               </svg>
               <router-link :to="'/news/new/' + newsSlide.id">
-                <svg fill="#00295F" width="30" height="30" viewBox="0 0 32 32" version="1.1"
-                     xmlns="http://www.w3.org/2000/svg" stroke="#00295F">
-                  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                <svg style="fill:#00295F;stroke:#00295F" width="30" height="30" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+                  <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                  <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
                   <g id="SVGRepo_iconCarrier"><title>link</title>
                     <path
                         d="M10.406 13.406l2.5-2.531c0.219-0.219 0.469-0.5 0.719-0.813 0.25-0.281 0.531-0.531 0.813-0.75 0.531-0.469 1.156-0.875 1.938-0.875 0.688 0 1.281 0.313 1.719 0.719s0.688 1 0.688 1.688c0 0.281-0.031 0.594-0.125 0.813-0.219 0.438-0.406 0.75-0.594 1-0.094 0.125-0.188 0.25-0.188 0.375 0 0.094 0 0.188 0.063 0.219 0.344 0.844 0.594 1.563 0.75 2.438 0.094 0.344 0.281 0.5 0.594 0.5 0.125 0 0.25-0.031 0.375-0.125 0.25-0.156 0.469-0.406 0.688-0.656 0.125-0.125 0.219-0.25 0.281-0.313 1.125-1.094 1.781-2.656 1.781-4.25 0-1.688-0.688-3.188-1.781-4.281-1.094-1.063-2.625-1.781-4.25-1.781s-3.188 0.656-4.281 1.813l-4.281 4.25c-1.125 1.156-1.75 2.656-1.75 4.25 0 0.469 0.188 1.438 0.5 2.344 0.313 0.875 0.719 1.656 1.25 1.656 0.281 0 0.875-0.469 1.375-1s1-1.125 1-1.344c0-0.156-0.125-0.344-0.25-0.625-0.156-0.281-0.219-0.625-0.219-1.031 0-0.625 0.25-1.25 0.688-1.688zM10.313 25.406l4.281-4.25c1.125-1.094 1.75-2.688 1.75-4.281 0-0.469-0.188-1.406-0.5-2.313-0.281-0.875-0.719-1.688-1.25-1.688-0.219 0-0.875 0.5-1.344 1.031-0.531 0.531-1.031 1.094-1.031 1.313 0 0.156 0.094 0.406 0.25 0.656 0.156 0.281 0.281 0.594 0.281 1-0.031 0.625-0.281 1.25-0.719 1.75l-2.531 2.5c-0.219 0.25-0.469 0.5-0.719 0.781l-0.781 0.781c-0.531 0.5-1.188 0.844-1.969 0.844-1.313 0-2.375-1.031-2.375-2.375 0-0.313 0.063-0.594 0.156-0.813 0.188-0.438 0.375-0.75 0.594-1 0.094-0.125 0.125-0.25 0.125-0.344 0-0.063-0.031-0.125-0.063-0.25-0.375-0.844-0.594-1.563-0.75-2.438-0.063-0.156-0.094-0.281-0.188-0.344-0.094-0.125-0.25-0.156-0.406-0.156-0.125 0-0.219 0.031-0.344 0.125-0.25 0.156-0.5 0.406-0.719 0.656-0.094 0.125-0.219 0.219-0.281 0.281-1.125 1.125-1.781 2.688-1.781 4.281 0 1.656 0.656 3.188 1.781 4.281 1.094 1.094 2.594 1.75 4.25 1.75 1.625 0 3.188-0.625 4.281-1.781z"></path>
@@ -765,24 +762,22 @@ const deleteMail = async (mailId) => {
                     </g>
                   </svg>
                 </router-link>
-                <svg @click="deleteMail(mail.id)" data-v-54c38a05="" width="32" height="32" viewBox="0 -0.5 21 21"
-                     version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-                     fill="#000000">
-                  <g id="SVGRepo_bgCarrier" stroke-width="0" data-v-54c38a05=""></g>
-                  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" data-v-54c38a05=""></g>
-                  <g id="SVGRepo_iconCarrier" data-v-54c38a05=""><title data-v-54c38a05="">delete [#1487]</title>
-                    <desc data-v-54c38a05="">Created with Sketch.</desc>
-                    <defs data-v-54c38a05=""></defs>
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" data-v-54c38a05="">
-                      <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" fill="#00295F"
-                         data-v-54c38a05="">
-                        <g id="icons" transform="translate(56.000000, 160.000000)" data-v-54c38a05="">
+                <svg @click="deleteMail(mail.id)" width="32" height="32" viewBox="0 -0.5 21 21"
+                     xmlns="http://www.w3.org/2000/svg" style="fill:#000000">
+                  <g id="SVGRepo_bgCarrier" style="stroke-width:0"></g>
+                  <g id="SVGRepo_tracerCarrier" style="stroke-linecap:round;stroke-linejoin:round"></g>
+                  <g id="SVGRepo_iconCarrier"><title>delete [#1487]</title>
+                    <desc>Created with Sketch.</desc>
+                    <defs></defs>
+                    <g id="Page-1" style="stroke:none;stroke-width:1;fill:none;fill-rule:evenodd">
+                      <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" style="fill:#00295F">
+                        <g id="icons" transform="translate(56.000000, 160.000000)">
                           <path
                               d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z"
-                              id="delete-[#1487]" data-v-54c38a05=""></path>
-                        </g>
-                      </g>
+                              id="delete-[#1487]"></path>
                     </g>
+                  </g>
+                </g>
                   </g>
                 </svg>
               </div>

--- a/src/views/FullSchedule.vue
+++ b/src/views/FullSchedule.vue
@@ -3,6 +3,7 @@ import {ref, computed, onMounted, onBeforeUnmount, watch} from 'vue'
 import {parserAxios} from '@/main'
 import Loader from '@/components/includes/Loader'
 import {userAuth} from '@/store/userAuth'
+import {GDialog} from 'gitart-vue-dialog'
 
 const store = userAuth()
 const scheduleData = ref(null)
@@ -23,6 +24,25 @@ const isDaysOpen = ref(false)
 const daysMultiselectRef = ref(null)
 const parseErrors = ref([])
 const parseErrorsExpanded = ref(false)
+const downloadError = ref('')
+const selectAllDaysCheckbox = ref(null)
+const selectAllTeachersCheckbox = ref(null)
+
+const downloadSchedule = async () => {
+  downloadError.value = ''
+  try {
+    const response = await parserAxios.get('lessons/xlsx/', { responseType: 'blob' })
+    const url = window.URL.createObjectURL(response.data)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'расписание.xlsx'
+    link.click()
+    window.URL.revokeObjectURL(url)
+  } catch (err) {
+    downloadError.value = 'Не удалось скачать расписание. Попробуйте позже'
+    setTimeout(() => { downloadError.value = '' }, 5000)
+  }
+}
 
 const zoomIn = () => {
   if (zoom.value < 2) zoom.value += 0.1
@@ -261,6 +281,18 @@ watch(selectedTeacherIds, (newVal) => {
     hideEmptyTeachers.value = false
   }
 }, {deep: true})
+
+watch(selectAllDaysState, (state) => {
+  if (selectAllDaysCheckbox.value) {
+    selectAllDaysCheckbox.value.indeterminate = state === 'indeterminate'
+  }
+})
+
+watch(selectAllState, (state) => {
+  if (selectAllTeachersCheckbox.value) {
+    selectAllTeachersCheckbox.value.indeterminate = state === 'indeterminate'
+  }
+})
 </script>
 
 <template>
@@ -286,9 +318,12 @@ watch(selectedTeacherIds, (newVal) => {
         </div>
       </div>
     </div>
-    <a :href="parserAxios.defaults.baseURL + 'lessons/xlsx/'" class="admin-button schedule-load">
+    <button @click="downloadSchedule" class="admin-button schedule-load">
       Скачать расписание
-    </a>
+    </button>
+    <div v-if="downloadError" class="download-error">
+      {{ downloadError }}
+    </div>
     <div class="controls">
       <label>
         <input type="checkbox" v-model="hideEmptyTeachers"/>
@@ -310,8 +345,8 @@ watch(selectedTeacherIds, (newVal) => {
           <li>
             <label>
               <input type="checkbox"
+                     ref="selectAllDaysCheckbox"
                      :checked="selectAllDaysState === 'checked'"
-                     :indeterminate.prop="selectAllDaysState === 'indeterminate'"
                      @change="toggleDaySelectAll"/>
               Выбрать все
             </label>
@@ -342,8 +377,8 @@ watch(selectedTeacherIds, (newVal) => {
           <li>
             <label>
               <input type="checkbox"
+                     ref="selectAllTeachersCheckbox"
                      :checked="selectAllState === 'checked'"
-                     :indeterminate.prop="selectAllState === 'indeterminate'"
                      @change="toggleSelectAll"/>
               Выбрать всех
             </label>
@@ -803,5 +838,16 @@ thead th.time-col {
   &__message {
     margin-left: 4px;
   }
+}
+
+.download-error {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 12px 16px;
+  background-color: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c6cb;
+  border-radius: 6px;
+  font-size: 14px;
 }
 </style>

--- a/src/views/FullSchedule.vue
+++ b/src/views/FullSchedule.vue
@@ -21,6 +21,8 @@ const multiselectRef = ref(null)
 const selectedDays = ref([])
 const isDaysOpen = ref(false)
 const daysMultiselectRef = ref(null)
+const parseErrors = ref([])
+const parseErrorsExpanded = ref(false)
 
 const zoomIn = () => {
   if (zoom.value < 2) zoom.value += 0.1
@@ -188,10 +190,33 @@ const deleteLesson = async () => {
   }
 }
 
+const fieldLabels = {
+  row: 'Строка',
+  course: 'Курс',
+  group: 'Группа',
+  course_map: 'Соответствие курса',
+  cell: 'Ячейка',
+  cell_format_skipped: 'Формат ячейки',
+  lesson_meta: 'Метаданные занятия'
+}
+
+const dismissParseErrors = () => {
+  parseErrors.value = []
+  sessionStorage.removeItem('scheduleParseErrors')
+}
+
 onMounted(() => {
   userRole.value = store.getRole
   loadSchedule()
   document.addEventListener('click', handleClickOutside)
+
+  const stored = sessionStorage.getItem('scheduleParseErrors')
+  if (stored) {
+    try {
+      parseErrors.value = JSON.parse(stored)
+    } catch (_) {}
+    sessionStorage.removeItem('scheduleParseErrors')
+  }
 })
 
 onBeforeUnmount(() => {
@@ -241,6 +266,26 @@ watch(selectedTeacherIds, (newVal) => {
 <template>
   <section v-if="scheduleData" class="full-schedule">
     <h1>Расписание</h1>
+    <div v-if="parseErrors.length" class="parse-warnings">
+      <div class="parse-warnings__header">
+        <span>Расписание загружено, но обнаружены проблемы ({{ parseErrors.length }})</span>
+        <div class="parse-warnings__actions">
+          <button @click="parseErrorsExpanded = !parseErrorsExpanded" class="parse-warnings__toggle">
+            {{ parseErrorsExpanded ? 'Свернуть' : 'Подробнее' }}
+          </button>
+          <button @click="dismissParseErrors" class="parse-warnings__close">&times;</button>
+        </div>
+      </div>
+      <div v-if="parseErrorsExpanded" class="parse-warnings__details">
+        <div v-for="(error, i) in parseErrors" :key="i" class="parse-warnings__item">
+          <span class="parse-warnings__field">{{ fieldLabels[error.field] || error.field }}</span>
+          <span v-if="error.row != null || error.col != null" class="parse-warnings__location">
+            ({{ error.row != null ? `строка ${error.row}` : '' }}{{ error.row != null && error.col != null ? ', ' : '' }}{{ error.col != null ? `столбец ${error.col}` : '' }})
+          </span>
+          <span class="parse-warnings__message">{{ error.message }}</span>
+        </div>
+      </div>
+    </div>
     <a :href="parserAxios.defaults.baseURL + 'lessons/xlsx/'" class="admin-button schedule-load">
       Скачать расписание
     </a>
@@ -682,5 +727,81 @@ thead th.time-col {
 
 .multiselect-list input[type="checkbox"] {
   margin-right: 10px;
+}
+
+.parse-warnings {
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  background-color: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 6px;
+  font-size: 14px;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 500;
+    color: #e65100;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__toggle {
+    background: none;
+    border: none;
+    color: $pr1;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    color: #999;
+    padding: 0 4px;
+    line-height: 1;
+
+    &:hover {
+      color: #333;
+    }
+  }
+
+  &__details {
+    margin-top: 12px;
+    max-height: 300px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__item {
+    padding: 6px 8px;
+    background-color: #fff3e0;
+    border-radius: 4px;
+    color: #333;
+  }
+
+  &__field {
+    font-weight: 500;
+  }
+
+  &__location {
+    color: #888;
+    margin: 0 4px;
+  }
+
+  &__message {
+    margin-left: 4px;
+  }
 }
 </style>


### PR DESCRIPTION
Реализовал информативный вывод ошибок при загрузке расписания.
Если парсер упал, то отображается следующее сообщение об ошибке:
<img width="1710" height="948" alt="image" src="https://github.com/user-attachments/assets/e718bdde-387c-4004-9e3a-55ed887c8020" />

Если парсер смог обработать файл, но с бека приходят какие-то предупреждения, то они отображаются следующим образом:
<img width="1710" height="949" alt="image" src="https://github.com/user-attachments/assets/6c1ecfe7-dd30-4219-a6b7-d2a186085a30" />
<img width="1709" height="947" alt="image" src="https://github.com/user-attachments/assets/b45c9927-86bb-4142-a5e9-c3a02f27917d" />

Также добавил обработку ошибки при попытке скачать расписание
<img width="1710" height="948" alt="image" src="https://github.com/user-attachments/assets/72ada050-3865-4c2e-a028-7094024bfc28" />

