### PR TITLE
ID11: Подсветка текущих пар в реальном времени

### DIFF
--- a/src/components/includes/Footer.vue
+++ b/src/components/includes/Footer.vue
@@ -3,11 +3,11 @@
     <div class="footer__container">
       <div class="footer__container-left">
         <nav class="footer-nav">
-          <router-link class="footer-nav__item hover-underline" to="/address">Адреса и контакты</router-link>
+          <router-link class="footer-nav__item hover-underline" to="/contacts">Адреса и контакты</router-link>
           <router-link class="footer-nav__item hover-underline" to="/confident">Политика конфиденциальности</router-link>
         </nav>
         <div class="footer-info">
-          <p class="footer-info__item">©Воронежский Государственный Университет 1997-2023 Все права защищены</p>
+          <p class="footer-info__item">©Воронежский Государственный Университет 1997-{{ currentYear }} Все права защищены</p>
           <p class="footer-info__item">При использовании материала ссылка обязательна</p>
         </div>
       </div>
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-
+const currentYear = new Date().getFullYear()
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/mainpage/MainNews.vue
+++ b/src/components/mainpage/MainNews.vue
@@ -10,22 +10,31 @@
           </svg>
         </router-link>
       </div>
-      <div class="news__container-field">
+      <div class="news__field">
         <Swiper
-            :slides-per-view="4"
-            :space-between="85"
-            :navigation="{
-              prevEl: prevEl,
-              nextEl: nextEl,
-            }"
-            :modules="[Navigation]"
+          :slides-per-view="4"
+          :space-between="30"
+          :navigation="{ prevEl, nextEl }"
+          :modules="[Navigation]"
         >
-          <SwiperSlide v-for="newsSlide in newsSlider">
-            <router-link :to="'/news/new/' + newsSlide.id" class="new">
-              <img :src="`${API_FILES_URL}/${newsSlide.imageLink}`" alt="" class="new__image">
-              <p class="new__date">{{ new Date(newsSlide.publicationAt).getDate() + ' ' + monthAssoc[newsSlide.publicationAt.split('-').reverse()[1]] }}</p>
-              <p class="new__text">{{ newsSlide.title }}</p>
-            </router-link>
+          <SwiperSlide v-for="newsSlide in newsSlider" :key="newsSlide.id">
+            <div class="new">
+              <router-link :to="'/news/new/' + newsSlide.id" class="new__link">
+                <div class="new__media">
+                  <img :src="`${API_FILES_URL}/${newsSlide.imageLink}`" alt="" class="new__image">
+                  <span class="new__date">
+                    {{ new Date(newsSlide.publicationAt).getDate() + ' ' + monthAssoc[newsSlide.publicationAt.split('-').reverse()[1]] }}
+                  </span>
+                  <span class="new__arrow" aria-hidden="true">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                  </span>
+                </div>
+                <p class="new__title">{{ newsSlide.title }}</p>
+                <span class="new__accent"></span>
+              </router-link>
+            </div>
           </SwiperSlide>
         </Swiper>
         <div class="slider-nav">
@@ -48,49 +57,33 @@
 <script setup>
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import { Navigation } from 'swiper'
-import {onMounted, ref} from "vue";
-import axios from "axios";
-import { API_FILES_URL } from '@/main';
+import { onMounted, ref } from 'vue'
+import axios from 'axios'
+import { API_FILES_URL } from '@/main'
 
 const prevEl = ref(null)
 const nextEl = ref(null)
-const monthAssoc = ref({
-  '01': 'января',
-  '02': 'февраля',
-  '03': 'марта',
-  '04': 'апреля',
-  '05': 'мая',
-  '06': 'июня',
-  '07': 'июля',
-  '08': 'августа',
-  '09': 'сентября',
-  '10': 'октября',
-  '11': 'ноября',
-  '12': 'декабря'
-})
 const newsSlider = ref([])
-
-onMounted(() => {
-    newsList()
-})
-
-const newsList = async () => {
-    await axios.get('news')
-        .then((news) => {
-            newsSlider.value = news.data
-            newsSlider.value.reverse().slice(0, 8)
-        })
+const monthAssoc = {
+  '01': 'января', '02': 'февраля', '03': 'марта', '04': 'апреля',
+  '05': 'мая', '06': 'июня', '07': 'июля', '08': 'августа',
+  '09': 'сентября', '10': 'октября', '11': 'ноября', '12': 'декабря'
 }
+
+onMounted(async () => {
+  const res = await axios.get('news')
+  newsSlider.value = res.data.reverse().slice(0, 8)
+})
 </script>
 
 <style lang="scss">
 @import "../../assets/styles/styles.scss";
 
-.news{
+.news {
   background: $pr3;
   padding: 80px 0;
 
-  &__container{
+  &__container {
     max-width: 1440px;
     margin: 0 auto;
     display: flex;
@@ -100,56 +93,122 @@ const newsList = async () => {
     @media (max-width: 1480px) {
       max-width: calc(100% - 40px);
     }
+  }
 
-    &-field{
-      width: 100%;
-      position: relative;
+  &__field {
+    width: 100%;
+    position: relative;
+
+    .slider-nav {
+      pointer-events: none;
+
+      &__button {
+        pointer-events: auto;
+      }
     }
   }
 }
 
-.new{
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 15px;
-  max-width: 296px;
+.new {
+  display: block;
+  width: 100%;
+  background: white;
+  border-radius: 10px;
+  overflow: hidden;
   position: relative;
-  cursor: pointer;
+  transition: box-shadow 0.25s ease;
+  box-shadow: 0 0 0 transparent;
 
-  &:before{
-    content: '';
-    position: absolute;
-    height: 100%;
-    width: 2px;
-    left: 0;
-    top: 0;
-    background: $pr2;
+  &__link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
   }
 
-  &__image{
-    width: 296px;
+  &__media {
+    position: relative;
+    width: 100%;
     height: 180px;
+    overflow: hidden;
+  }
+
+  &__image {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
-    border-radius: 0 10px 10px 0;
+    display: block;
+    pointer-events: none;
   }
 
-  &__date{
-    font-size: 18px;
-    line-height: 21px;
-    color: white;
+  &__date {
+    position: absolute;
+    top: 12px;
+    right: 12px;
     background: $pr2;
-    border-radius: 0 10px 10px 0;
-    padding: 7px 14px;
+    color: white;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    padding: 7px 12px;
+    border-radius: 20px;
+    letter-spacing: 0.2px;
+    box-shadow: 0 2px 6px rgba(0, 41, 95, 0.18);
+    pointer-events: none;
   }
 
-  &__text{
-    font-size: 24px;
-    line-height: 28px;
-    background: white;
-    padding: 10px;
-    border-radius: 0 10px 10px 0;
-    height: 188px;
+  &__arrow {
+    position: absolute;
+    bottom: 12px;
+    right: 12px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: $pr2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+  }
+
+  &__title {
+    padding: 20px;
+    font-size: 20px;
+    line-height: 26px;
+    color: $pr1;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin: 0;
+    min-height: calc(26px * 3 + 40px);
+    box-sizing: border-box;
+  }
+
+  &__accent {
+    display: block;
+    height: 2px;
+    width: 40px;
+    background: $pr2;
+    margin: 0 20px 20px;
+    transition: width 0.3s ease;
+    pointer-events: none;
+  }
+
+  &:hover {
+    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+
+    .new__arrow {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .new__accent {
+      width: 80px;
+    }
   }
 }
 </style>

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -27,6 +27,54 @@ const newsDisabler = ref([])
 const currNews = ref([])
 const scheduleUrl = ref(null)
 const scheduleError = ref('')
+const weekConfigForm = ref({ reference_date: '', is_denominator: false })
+const weekConfigLoaded = ref(false)
+const weekConfigError = ref('')
+const weekConfigSuccess = ref('')
+const weekConfigSaving = ref(false)
+const weekConfigEditing = ref(false)
+const currentIsDenominator = ref(null)
+
+const weekdayNames = ['воскресенье', 'понедельник', 'вторник', 'среда', 'четверг', 'пятница', 'суббота']
+
+const formatReferenceDate = (iso) => {
+  if (!iso) return ''
+  const d = new Date(iso + 'T00:00:00')
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('ru-RU', { day: '2-digit', month: 'long', year: 'numeric' })
+}
+
+const referenceDateIsMonday = computed(() => {
+  const v = weekConfigForm.value.reference_date
+  if (!v) return null
+  const d = new Date(v + 'T00:00:00')
+  if (isNaN(d.getTime())) return false
+  return d.getDay() === 1
+})
+
+const referenceDateWeekday = computed(() => {
+  const v = weekConfigForm.value.reference_date
+  if (!v) return ''
+  const d = new Date(v + 'T00:00:00')
+  if (isNaN(d.getTime())) return ''
+  return weekdayNames[d.getDay()]
+})
+
+const toLocalISODate = (d) => {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+const shiftReferenceDateByWeek = (weeks) => {
+  const v = weekConfigForm.value.reference_date
+  if (!v) return
+  const d = new Date(v + 'T00:00:00')
+  if (isNaN(d.getTime())) return
+  d.setDate(d.getDate() + weeks * 7)
+  weekConfigForm.value.reference_date = toLocalISODate(d)
+}
 const userList = ref([])
 const sortOption = ref('1');
 const filterOption = ref('');
@@ -108,6 +156,7 @@ onMounted(() => {
   eventList()
   getMails()
   checkRole()
+  loadWeekConfig()
 
   tabsHandler(activeItem.value);
 })
@@ -352,6 +401,67 @@ const deleteNews = async (artId, index) => {
       .then(() => {
         newsShow.value[index] = false
       })
+}
+
+const loadWeekConfig = async () => {
+  try {
+    const response = await parserAxios.get('lessons/week_config/')
+    weekConfigForm.value = {
+      reference_date: response.data.reference_date ?? '',
+      is_denominator: Boolean(response.data.is_denominator)
+    }
+    currentIsDenominator.value = response.data.current_is_denominator ?? null
+    weekConfigLoaded.value = true
+  } catch (err) {
+    weekConfigError.value = 'Не удалось загрузить настройку чередования недель'
+  }
+}
+
+const cancelWeekConfigEdit = () => {
+  weekConfigEditing.value = false
+  weekConfigError.value = ''
+  loadWeekConfig()
+}
+
+const isMondayISO = (dateStr) => {
+  if (!dateStr) return false
+  const d = new Date(dateStr + 'T00:00:00')
+  return !isNaN(d.getTime()) && d.getDay() === 1
+}
+
+const saveWeekConfig = async () => {
+  weekConfigError.value = ''
+  weekConfigSuccess.value = ''
+
+  if (!weekConfigForm.value.reference_date) {
+    weekConfigError.value = 'Укажите опорную дату'
+    return
+  }
+  if (!isMondayISO(weekConfigForm.value.reference_date)) {
+    weekConfigError.value = 'Опорная дата должна быть понедельником'
+    return
+  }
+
+  weekConfigSaving.value = true
+  try {
+    await parserAxios.patch('lessons/week_config/', {
+      reference_date: weekConfigForm.value.reference_date,
+      is_denominator: weekConfigForm.value.is_denominator
+    })
+    weekConfigSuccess.value = 'Настройка сохранена'
+    setTimeout(() => { weekConfigSuccess.value = '' }, 3000)
+    weekConfigEditing.value = false
+    await loadWeekConfig()
+  } catch (err) {
+    const status = err.response?.status
+    if (status === 400) {
+      weekConfigError.value = 'Некорректные данные. Проверьте опорную дату'
+    } else {
+      weekConfigError.value = 'Не удалось сохранить настройку'
+    }
+  } finally {
+    weekConfigSaving.value = false
+  }
 }
 
 const uploadSchedule = async () => {
@@ -657,6 +767,77 @@ const deleteMail = async (mailId) => {
         </div>
         <div v-if="scheduleError" class="schedule-error">
           {{ scheduleError }}
+        </div>
+        <div v-if="weekConfigLoaded" class="week-config">
+          <div class="week-config__summary" v-if="!weekConfigEditing">
+            <span>
+              Сейчас идёт <b>{{ currentIsDenominator ? 'знаменатель' : 'числитель' }}</b>.
+              Опорная неделя — {{ formatReferenceDate(weekConfigForm.reference_date) }}
+              ({{ weekConfigForm.is_denominator ? 'знаменатель' : 'числитель' }}).
+            </span>
+            <button class="week-config__link" @click="weekConfigEditing = true">Изменить</button>
+          </div>
+
+          <div class="week-config__editor" v-else>
+            <div class="week-config__row">
+              <label class="week-config__field">
+                <span>Опорный понедельник</span>
+                <input type="date" v-model="weekConfigForm.reference_date">
+                <span v-if="weekConfigForm.reference_date && referenceDateIsMonday === false"
+                      class="week-config__inline-hint">
+                  выбранная дата — {{ referenceDateWeekday }}, нужен понедельник
+                </span>
+              </label>
+              <button type="button"
+                      class="week-config__shift"
+                      :disabled="!weekConfigForm.reference_date"
+                      @click="shiftReferenceDateByWeek(1)">
+                +1 неделя
+              </button>
+              <button type="button"
+                      class="week-config__shift"
+                      :disabled="!weekConfigForm.reference_date"
+                      @click="shiftReferenceDateByWeek(-1)">
+                −1 неделя
+              </button>
+            </div>
+
+            <div class="week-config__row">
+              <div class="week-config__toggle" role="radiogroup" aria-label="Тип опорной недели">
+                <button type="button"
+                        role="radio"
+                        :aria-checked="!weekConfigForm.is_denominator"
+                        :class="{ active: !weekConfigForm.is_denominator }"
+                        @click="weekConfigForm.is_denominator = false">
+                  Числитель
+                </button>
+                <button type="button"
+                        role="radio"
+                        :aria-checked="weekConfigForm.is_denominator"
+                        :class="{ active: weekConfigForm.is_denominator }"
+                        @click="weekConfigForm.is_denominator = true">
+                  Знаменатель
+                </button>
+              </div>
+            </div>
+
+            <div class="week-config__actions">
+              <button @click="saveWeekConfig"
+                      :disabled="weekConfigSaving || referenceDateIsMonday === false"
+                      class="admin-button">
+                {{ weekConfigSaving ? 'Сохранение…' : 'Сохранить' }}
+              </button>
+              <button type="button"
+                      class="week-config__link"
+                      :disabled="weekConfigSaving"
+                      @click="cancelWeekConfigEdit">
+                Отмена
+              </button>
+            </div>
+          </div>
+
+          <div v-if="weekConfigError" class="schedule-error">{{ weekConfigError }}</div>
+          <div v-if="weekConfigSuccess" class="week-config__success">{{ weekConfigSuccess }}</div>
         </div>
       </div>
       <div v-show="admRole === 'ADMIN' && activeItem === 'employees'" class="admin__view-item">
@@ -1066,6 +1247,126 @@ const deleteMail = async (mailId) => {
   border: 1px solid #f5c6cb;
   border-radius: 6px;
   font-size: 14px;
+}
+
+.week-config {
+  margin-top: 20px;
+  max-width: 720px;
+  font-size: 14px;
+
+  &__summary {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    color: #333;
+  }
+
+  &__link {
+    background: none;
+    border: none;
+    color: #00295F;
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0;
+    font-size: 14px;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+  }
+
+  &__editor {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 4px;
+  }
+
+  &__row {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    input[type="date"] {
+      padding: 6px 8px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 14px;
+    }
+  }
+
+  &__inline-hint {
+    color: #b71c1c;
+    font-size: 12px;
+  }
+
+  &__shift {
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+
+    &:hover:not(:disabled) {
+      border-color: #00295F;
+      color: #00295F;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+  }
+
+  &__toggle {
+    display: inline-flex;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    overflow: hidden;
+
+    button {
+      padding: 6px 14px;
+      background: white;
+      border: none;
+      cursor: pointer;
+      font-size: 13px;
+      transition: background-color 0.2s, color 0.2s;
+
+      & + button {
+        border-left: 1px solid #ccc;
+      }
+
+      &.active {
+        background-color: #00295F;
+        color: white;
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__success {
+    margin-top: 10px;
+    padding: 8px 12px;
+    background-color: #e8f5e9;
+    color: #2e7d32;
+    border: 1px solid #c8e6c9;
+    border-radius: 6px;
+  }
 }
 
 .new-view {

--- a/src/views/AllNews.vue
+++ b/src/views/AllNews.vue
@@ -1,64 +1,63 @@
-<!--2015-10-05T08:30:00-->
 <template>
   <section class="news-all">
-      <h1 class="news-all__title">Новости</h1>
-      <div class="news-all__field">
-          <router-link :to="'/news/new/' + newsSlide.id" v-for="newsSlide in newsSlider" class="new">
-              <img :src="`${API_FILES_URL}/${newsSlide.imageLink}`" alt="" class="new__image">
-              <p class="new__date" v-if="newsSlide.publicationAt">{{ new Date(newsSlide.publicationAt).getDate() + ' ' + monthAssoc[newsSlide.publicationAt.split('-').reverse()[1]] }}</p>
-              <p class="new__text">{{ newsSlide.title }}</p>
-          </router-link>
+    <h1 class="news-all__title">Новости</h1>
+    <div class="news-all__field">
+      <div v-for="newsSlide in newsSlider" :key="newsSlide.id" class="new">
+        <router-link :to="'/news/new/' + newsSlide.id" class="new__link">
+          <div class="new__media">
+            <img :src="`${API_FILES_URL}/${newsSlide.imageLink}`" alt="" class="new__image">
+            <span class="new__date" v-if="newsSlide.publicationAt">
+              {{ new Date(newsSlide.publicationAt).getDate() + ' ' + monthAssoc[newsSlide.publicationAt.split('-').reverse()[1]] }}
+            </span>
+            <span class="new__arrow" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </div>
+          <p class="new__title">{{ newsSlide.title }}</p>
+          <span class="new__accent"></span>
+        </router-link>
       </div>
+    </div>
   </section>
 </template>
 
 <script setup>
-import {onMounted, ref} from "vue";
-import axios from "axios";
-import { API_FILES_URL } from '@/main';
+import { onMounted, ref } from 'vue'
+import axios from 'axios'
+import { API_FILES_URL } from '@/main'
 
 const newsSlider = ref([])
-const monthAssoc = ref({
-    '01': 'января',
-    '02': 'февраля',
-    '03': 'марта',
-    '04': 'апреля',
-    '05': 'мая',
-    '06': 'июня',
-    '07': 'июля',
-    '08': 'августа',
-    '09': 'сентября',
-    '10': 'октября',
-    '11': 'ноября',
-    '12': 'декабря'
-})
-
-onMounted(() => {
-    newsList()
-})
-
-const newsList = async () => {
-    await axios.get('news')
-        .then((news) => {
-            newsSlider.value = news.data.reverse()
-        })
+const monthAssoc = {
+  '01': 'января', '02': 'февраля', '03': 'марта', '04': 'апреля',
+  '05': 'мая', '06': 'июня', '07': 'июля', '08': 'августа',
+  '09': 'сентября', '10': 'октября', '11': 'ноября', '12': 'декабря'
 }
+
+onMounted(async () => {
+  const res = await axios.get('news')
+  newsSlider.value = res.data.reverse()
+})
 </script>
 
 <style lang="scss" scoped>
-.news-all{
+.news-all {
   max-width: 1440px;
   margin: 0 auto 80px;
 
-  &__field{
-    display: flex;
-    align-items: stretch;
-    flex-wrap: wrap;
-    gap: 85px;
+  @media (max-width: 1480px) {
+    max-width: calc(100% - 40px);
   }
 
-  &__title{
+  &__title {
     margin-bottom: 40px;
+  }
+
+  &__field {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 30px;
   }
 }
 </style>

--- a/src/views/FullSchedule.vue
+++ b/src/views/FullSchedule.vue
@@ -234,6 +234,20 @@ const areLessonsEqual = (lessons) => {
       && lessons[0].placement === lessons[1].placement
 }
 
+const hasContent = (lesson) => !!(lesson && (lesson.name || lesson.groups || lesson.placement))
+
+const activeBadgePosition = (day, time, pair) => {
+  if (!day.is_current || !time.is_current) return null
+  if (!pair || pair.length === 0) return null
+  if (areLessonsEqual(pair)) {
+    return hasContent(pair[0]) ? 'top' : null
+  }
+  const isDenom = scheduleData.value?.is_denominator
+  const target = pair[isDenom ? 1 : 0]
+  if (!hasContent(target)) return null
+  return isDenom ? 'bottom' : 'top'
+}
+
 const dismissParseErrors = () => {
   parseErrors.value = []
   sessionStorage.removeItem('scheduleParseErrors')
@@ -446,17 +460,29 @@ watch(selectAllState, (state) => {
           </thead>
           <tbody>
           <template v-for="(day, dIndex) in visibleSchedule" :key="dIndex">
-            <tr v-for="(time, tIndex) in day.times" :key="tIndex">
-              <td v-if="tIndex === 0" class="sticky-col day-col" :rowspan="day.times.length">
+            <tr v-for="(time, tIndex) in day.times" :key="tIndex" :class="{ 'is-current-time': time.is_current && day.is_current }">
+              <td v-if="tIndex === 0"
+                  class="sticky-col day-col"
+                  :class="{ 'is-current-day': day.is_current }"
+                  :rowspan="day.times.length">
                 {{ day.weekday }}
               </td>
-              <td class="sticky-col time-col">{{ time.time }}</td>
+              <td class="sticky-col time-col" :class="{ 'is-current-time-cell': time.is_current && day.is_current }">{{ time.time }}</td>
               <td v-for="index in visibleTeacherIndices"
                   :key="index"
                   class="lesson-cell">
+                <span v-if="activeBadgePosition(day, time, time.lessons[index])"
+                      class="lesson-now-badge"
+                      :class="'lesson-now-badge--' + activeBadgePosition(day, time, time.lessons[index])"
+                      data-tooltip="Эта пара идёт сейчас"
+                      aria-label="Эта пара идёт сейчас"></span>
                 <template v-for="(singleLesson, sIndex) in time.lessons[index]" :key="sIndex">
                   <template v-if="!(sIndex === 1 && areLessonsEqual(time.lessons[index]))">
-                  <div class="lesson-part" :class="{ editable: isEditable, 'lesson-part--merged': areLessonsEqual(time.lessons[index]) }">
+                  <div class="lesson-part"
+                       :class="{
+                         editable: isEditable,
+                         'lesson-part--merged': areLessonsEqual(time.lessons[index])
+                       }">
                     {{ singleLesson.name }} {{ singleLesson.groups }} {{ singleLesson.placement }}
                     <button v-if="isEditable"
                             @click="openModal(singleLesson.name, singleLesson.groups, singleLesson.placement, singleLesson.id)"
@@ -917,6 +943,79 @@ thead th.time-col {
     margin-left: 4px;
   }
 }
+
+.is-current-day,
+.is-current-time-cell {
+  color: $pr1 !important;
+  font-weight: 700;
+}
+
+.lesson-now-badge {
+  position: absolute;
+  right: 8px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: $pr1;
+  box-shadow: 0 0 0 2px white, 0 0 0 3px rgba($pr1, 0.25);
+  cursor: help;
+  z-index: 4;
+  animation: lesson-now-pulse 2.6s ease-out infinite;
+
+  &--top {
+    top: 8px;
+  }
+
+  &--bottom {
+    top: calc(50% + 6px);
+  }
+
+  &::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: 50%;
+    right: calc(100% + 12px);
+    transform: translateY(-50%);
+    background: $pr1;
+    color: white;
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: calc(100% + 6px);
+    transform: translateY(-50%);
+    border: 6px solid transparent;
+    border-left-color: $pr1;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+  }
+
+  &:hover::after,
+  &:hover::before {
+    opacity: 1;
+  }
+}
+
+@keyframes lesson-now-pulse {
+  0% {
+    box-shadow: 0 0 0 2px white, 0 0 0 3px rgba($pr1, 0.25);
+  }
+  100% {
+    box-shadow: 0 0 0 2px white, 0 0 0 7px rgba($pr1, 0);
+  }
+}
+
 
 .download-error {
   margin-top: 10px;

--- a/src/views/FullSchedule.vue
+++ b/src/views/FullSchedule.vue
@@ -959,7 +959,7 @@ thead th.time-col {
   background: $pr1;
   box-shadow: 0 0 0 2px white, 0 0 0 3px rgba($pr1, 0.25);
   cursor: help;
-  z-index: 4;
+  z-index: 2;
   animation: lesson-now-pulse 2.6s ease-out infinite;
 
   &--top {


### PR DESCRIPTION
ID11: Подсветка текущих пар в реальном времени

Добавил real-time подсветку в FullSchedule.vue: активный день и время выделяются жирным, у идущей сейчас пары — пульсирующий кружок в углу ячейки (учитывает числитель/знаменатель)
<img width="1710" height="947" alt="image" src="https://github.com/user-attachments/assets/07abb26a-04d3-48ac-9f87-093aa197962e" />

В Admin.vue во вкладке «Расписание» — новый блок для настройки опорной недели
<img width="1710" height="947" alt="image" src="https://github.com/user-attachments/assets/63784aea-0706-4dfb-80a7-cd0fcf1a9742" />

В придачу поменял дизайн карточек новостей на главной и в футере сделал год динамическим
<img width="1710" height="592" alt="image" src="https://github.com/user-attachments/assets/9787b3a8-be46-451b-adab-c3d704c41e1c" />
