### PR TITLE
Feature/students import

### DIFF
--- a/src/components/includes/Header.vue
+++ b/src/components/includes/Header.vue
@@ -70,7 +70,7 @@
     <GDialog v-model="dialogState" :max-width="500">
       <!-- Обычный логин -->
       <form
-        v-if="!twoFactorRequired"
+        v-if="!twoFactorRequired && !bindRequired"
         @submit.prevent="auth"
         class="login-modal"
       >
@@ -97,6 +97,36 @@
         </div>
         <p class="login-modal__error">{{ authError }}</p>
         <button type="submit" class="login-modal__submit">Вход</button>
+      </form>
+
+      <!-- Шаг bind: ввод Moodle-логина для связки с AD -->
+      <form
+        v-else-if="bindRequired"
+        @submit.prevent="bindStudent"
+        class="login-modal"
+      >
+        <img src="../../assets/img/logo.jpg" alt="" class="login-modal__logo" />
+        <h3 class="login-modal__2fa-title">Подтверждение студента</h3>
+        <p class="login-modal__2fa-subtitle">
+          Введите ваш логин в Moodle, чтобы подтвердить, что вы — студент кафедры.
+        </p>
+        <div class="login-modal__inputs">
+          <div class="login-modal__inputs-item">
+            <p class="login-modal__inputs-item_name">Логин в Moodle</p>
+            <input
+              type="text"
+              class="login-modal__inputs-item_input"
+              v-model="bindMoodleLogin"
+              :disabled="bindLoading"
+              required
+            />
+          </div>
+        </div>
+        <p class="login-modal__error">{{ authError }}</p>
+        <button type="submit" class="login-modal__submit" :disabled="bindLoading">
+          Подтвердить
+        </button>
+        <button type="button" class="login-modal__back" @click="backFromBind">Назад</button>
       </form>
 
       <!-- Ввод кода 2FA -->
@@ -143,6 +173,9 @@ const twoFactorEmail = ref("");
 const twoFactorLoading = ref(false);
 const twoFactorCooldown = ref(60);
 const loginOtpRef = ref(null);
+const bindRequired = ref(false);
+const bindMoodleLogin = ref("");
+const bindLoading = ref(false);
 
 const isAuth = computed(() => store.getIsAuth);
 const navTabs = computed(() => tabsStore.visibleTabs);
@@ -165,7 +198,11 @@ const auth = async () => {
       password: password.value,
       rememberMe: true,
     });
-    if (response.data.requiresTwoFactor) {
+    if (response.data.bindRequired) {
+      bindRequired.value = true;
+      bindMoodleLogin.value = "";
+      authError.value = "";
+    } else if (response.data.requiresTwoFactor) {
       twoFactorRequired.value = true;
       twoFactorEmail.value = response.data.email;
       twoFactorCooldown.value = 60;
@@ -243,6 +280,43 @@ const resend2fa = async () => {
 const backToLogin = () => {
   twoFactorRequired.value = false;
   twoFactorEmail.value = "";
+  authError.value = "";
+};
+
+const bindStudent = async () => {
+  if (!bindMoodleLogin.value.trim()) {
+    authError.value = "Введите логин в Moodle";
+    return;
+  }
+  authError.value = "";
+  bindLoading.value = true;
+  try {
+    const response = await axios.post("auth/student/bind", {
+      adLogin: login.value,
+      password: password.value,
+      moodleLogin: bindMoodleLogin.value.trim(),
+    });
+    const token = response.data.accessToken;
+    store.setAuth(token, response.data.mainRole);
+    location.reload();
+  } catch (err) {
+    if (err.response?.status === 403) {
+      authError.value = "Вы не являетесь студентом кафедры";
+    } else if (err.response?.status === 401) {
+      authError.value = "Неверный логин или пароль";
+    } else if (err.response?.status === 409) {
+      authError.value = "Этот AD-логин уже используется";
+    } else {
+      authError.value = "Не удалось выполнить вход";
+    }
+  } finally {
+    bindLoading.value = false;
+  }
+};
+
+const backFromBind = () => {
+  bindRequired.value = false;
+  bindMoodleLogin.value = "";
   authError.value = "";
 };
 

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -100,6 +100,151 @@ const activeEmployeesTab = ref(
   localStorage.getItem("employeesActiveTab") ?? "employees",
 );
 const fileInput = ref(null);
+
+const importDialogState = ref(false);
+const importSource = ref("file");
+const importFile = ref(null);
+const importFileInput = ref(null);
+const importUrl = ref("");
+const importLoading = ref(false);
+const importResult = ref(null);
+const importError = ref("");
+
+const openImportDialog = () => {
+  importDialogState.value = true;
+  importSource.value = "file";
+  importFile.value = null;
+  importUrl.value = "";
+  importResult.value = null;
+  importError.value = "";
+};
+
+const closeImportDialog = () => {
+  importDialogState.value = false;
+  if (importFileInput.value) importFileInput.value.value = "";
+};
+
+const onImportFileChange = (event) => {
+  importFile.value = event.target.files[0] || null;
+  importError.value = "";
+};
+
+const submitImport = async () => {
+  importLoading.value = true;
+  importError.value = "";
+  importResult.value = null;
+  try {
+    let response;
+    if (importSource.value === "file") {
+      if (!importFile.value) {
+        importError.value = "Выберите файл .xlsx или .csv";
+        return;
+      }
+      const formData = new FormData();
+      formData.append("file", importFile.value);
+      response = await axios.post("students/import", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+    } else {
+      const url = importUrl.value.trim();
+      if (!url) {
+        importError.value = "Введите URL Google Sheets";
+        return;
+      }
+      response = await axios.post("students/import/google-sheet", { url });
+    }
+    importResult.value = response.data;
+  } catch (err) {
+    if (err.response?.data?.errors) {
+      importResult.value = err.response.data;
+    } else if (typeof err.response?.data === "string") {
+      importError.value = err.response.data;
+    } else {
+      importError.value = "Не удалось выполнить импорт";
+    }
+  } finally {
+    importLoading.value = false;
+  }
+};
+
+const finishImport = () => {
+  closeImportDialog();
+  location.reload();
+};
+
+const topicsImportDialogState = ref(false);
+const topicsImportSource = ref("file");
+const topicsImportFile = ref(null);
+const topicsImportFileInput = ref(null);
+const topicsImportUrl = ref("");
+const topicsImportLoading = ref(false);
+const topicsImportResult = ref(null);
+const topicsImportError = ref("");
+
+const openTopicsImportDialog = () => {
+  topicsImportDialogState.value = true;
+  topicsImportSource.value = "file";
+  topicsImportFile.value = null;
+  topicsImportUrl.value = "";
+  topicsImportResult.value = null;
+  topicsImportError.value = "";
+};
+
+const closeTopicsImportDialog = () => {
+  topicsImportDialogState.value = false;
+  if (topicsImportFileInput.value) topicsImportFileInput.value.value = "";
+};
+
+const onTopicsFileChange = (event) => {
+  topicsImportFile.value = event.target.files[0] || null;
+  topicsImportError.value = "";
+};
+
+const submitTopicsImport = async () => {
+  topicsImportLoading.value = true;
+  topicsImportError.value = "";
+  topicsImportResult.value = null;
+  try {
+    let response;
+    if (topicsImportSource.value === "file") {
+      if (!topicsImportFile.value) {
+        topicsImportError.value = "Выберите файл .xlsx или .csv";
+        return;
+      }
+      const formData = new FormData();
+      formData.append("file", topicsImportFile.value);
+      response = await axios.post("students/topics/import", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+    } else {
+      const url = topicsImportUrl.value.trim();
+      if (!url) {
+        topicsImportError.value = "Введите URL Google Sheets";
+        return;
+      }
+      response = await axios.post("students/topics/import/google-sheet", {
+        url,
+      });
+    }
+    topicsImportResult.value = response.data;
+  } catch (err) {
+    if (err.response?.data?.errors) {
+      topicsImportResult.value = err.response.data;
+    } else if (typeof err.response?.data === "string") {
+      topicsImportError.value = err.response.data;
+    } else {
+      topicsImportError.value = "Не удалось выполнить импорт";
+    }
+  } finally {
+    topicsImportLoading.value = false;
+  }
+};
+
+const finishTopicsImport = () => {
+  closeTopicsImportDialog();
+  location.reload();
+};
+
 const eventArr = ref([]);
 const monthAssoc = ref({
   "01": "января",
@@ -1538,9 +1683,25 @@ const deleteMail = async (mailId) => {
           <div class="admin-users__item">
             <div class="admin-users__item-head">
               <p class="admin-users__item-head_name">Студенты</p>
-              <router-link to="/admin/create_student" class="admin-button"
-                >Добавить</router-link
-              >
+              <div class="admin-users__item-head_actions">
+                <button
+                  type="button"
+                  class="admin-button"
+                  @click="openImportDialog"
+                >
+                  Импорт студентов
+                </button>
+                <button
+                  type="button"
+                  class="admin-button"
+                  @click="openTopicsImportDialog"
+                >
+                  Импорт тем
+                </button>
+                <router-link to="/admin/create_student" class="admin-button"
+                  >Добавить</router-link
+                >
+              </div>
             </div>
             <div class="admin-users__item-list">
               <StudentsListTable />
@@ -1718,11 +1879,334 @@ const deleteMail = async (mailId) => {
     </div>
   </GDialog>
 
+  <GDialog v-model="importDialogState" :max-width="640">
+    <div class="import-modal">
+      <h3 class="import-modal__title">Импорт студентов</h3>
+
+      <div v-if="!importResult" class="import-modal__form">
+        <p class="import-modal__hint">
+          Загрузите выгрузку участников курса из Moodle.
+        </p>
+
+        <div class="import-modal__tabs">
+          <button
+            type="button"
+            :class="{ active: importSource === 'file' }"
+            @click="importSource = 'file'"
+          >
+            Файл .xlsx/.csv
+          </button>
+          <button
+            type="button"
+            :class="{ active: importSource === 'gsheet' }"
+            @click="importSource = 'gsheet'"
+          >
+            Ссылка Google Sheets
+          </button>
+        </div>
+
+        <input
+          v-if="importSource === 'file'"
+          ref="importFileInput"
+          type="file"
+          accept=".xlsx,.csv"
+          class="import-modal__file"
+          @change="onImportFileChange"
+          :disabled="importLoading"
+        />
+        <div v-else class="import-modal__url">
+          <input
+            v-model="importUrl"
+            type="url"
+            placeholder="https://docs.google.com/spreadsheets/..."
+            class="import-modal__url-input"
+            :disabled="importLoading"
+          />
+          <p class="import-modal__hint">
+            Таблица должна быть открыта по ссылке (Файл → Поделиться → Доступ
+            по ссылке: Просмотр).
+          </p>
+        </div>
+
+        <p v-if="importError" class="import-modal__error">{{ importError }}</p>
+        <Loader v-if="importLoading" />
+        <div class="import-modal__actions">
+          <button
+            class="admin-button"
+            @click="closeImportDialog"
+            :disabled="importLoading"
+          >
+            Отмена
+          </button>
+          <button
+            class="admin-button"
+            @click="submitImport"
+            :disabled="importLoading"
+          >
+            Импортировать
+          </button>
+        </div>
+      </div>
+
+      <div v-else class="import-modal__result">
+        <p>Создано: <strong>{{ importResult.created }}</strong></p>
+        <p>Обновлено: <strong>{{ importResult.updated }}</strong></p>
+        <p>Пропущено: <strong>{{ importResult.skipped ?? 0 }}</strong></p>
+        <p>Ошибок: <strong>{{ importResult.errors.length }}</strong></p>
+
+        <table v-if="importResult.errors.length" class="import-modal__errors">
+          <thead>
+            <tr>
+              <th>Строка</th>
+              <th>Поле</th>
+              <th>Сообщение</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(err, idx) in importResult.errors" :key="idx">
+              <td>{{ err.row }}</td>
+              <td>{{ err.field }}</td>
+              <td>{{ err.message }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="import-modal__actions">
+          <button class="admin-button" @click="finishImport">Закрыть</button>
+        </div>
+      </div>
+    </div>
+  </GDialog>
+
+  <GDialog v-model="topicsImportDialogState" :max-width="640">
+    <div class="import-modal">
+      <h3 class="import-modal__title">Импорт тем и научных руководителей</h3>
+
+      <div v-if="!topicsImportResult" class="import-modal__form">
+        <p class="import-modal__hint">
+          Перед импортом убедитесь, что студенты уже добавлены в систему. Темы
+          для отсутствующих студентов будут отклонены с ошибкой.
+        </p>
+        <p class="import-modal__hint">
+          Повторный импорт перезаписывает темы целиком — пустые ячейки в файле
+          затрут существующие значения.
+        </p>
+
+        <div class="import-modal__tabs">
+          <button
+            type="button"
+            :class="{ active: topicsImportSource === 'file' }"
+            @click="topicsImportSource = 'file'"
+          >
+            Файл .xlsx/.csv
+          </button>
+          <button
+            type="button"
+            :class="{ active: topicsImportSource === 'gsheet' }"
+            @click="topicsImportSource = 'gsheet'"
+          >
+            Ссылка Google Sheets
+          </button>
+        </div>
+
+        <input
+          v-if="topicsImportSource === 'file'"
+          ref="topicsImportFileInput"
+          type="file"
+          accept=".xlsx,.csv"
+          class="import-modal__file"
+          @change="onTopicsFileChange"
+          :disabled="topicsImportLoading"
+        />
+        <div v-else class="import-modal__url">
+          <input
+            v-model="topicsImportUrl"
+            type="url"
+            placeholder="https://docs.google.com/spreadsheets/..."
+            class="import-modal__url-input"
+            :disabled="topicsImportLoading"
+          />
+          <p class="import-modal__hint">
+            Таблица должна быть открыта по ссылке (Файл → Поделиться → Доступ
+            по ссылке: Просмотр).
+          </p>
+        </div>
+
+        <p v-if="topicsImportError" class="import-modal__error">
+          {{ topicsImportError }}
+        </p>
+        <Loader v-if="topicsImportLoading" />
+
+        <div class="import-modal__actions">
+          <button
+            class="admin-button"
+            @click="closeTopicsImportDialog"
+            :disabled="topicsImportLoading"
+          >
+            Отмена
+          </button>
+          <button
+            class="admin-button"
+            @click="submitTopicsImport"
+            :disabled="topicsImportLoading"
+          >
+            Импортировать
+          </button>
+        </div>
+      </div>
+
+      <div v-else class="import-modal__result">
+        <p>
+          Обработано:
+          <strong>{{ topicsImportResult.processedRows }}</strong>
+        </p>
+        <p>Создано: <strong>{{ topicsImportResult.createdRows }}</strong></p>
+        <p>
+          Обновлено: <strong>{{ topicsImportResult.updatedRows }}</strong>
+        </p>
+        <p>
+          Ошибок: <strong>{{ topicsImportResult.errors.length }}</strong>
+        </p>
+
+        <table
+          v-if="topicsImportResult.errors.length"
+          class="import-modal__errors"
+        >
+          <thead>
+            <tr>
+              <th>Строка</th>
+              <th>Логин студента</th>
+              <th>Сообщение</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(err, idx) in topicsImportResult.errors" :key="idx">
+              <td>{{ err.rowNumber }}</td>
+              <td>{{ err.studentLogin || "—" }}</td>
+              <td>{{ err.message }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="import-modal__actions">
+          <button class="admin-button" @click="finishTopicsImport">
+            Закрыть
+          </button>
+        </div>
+      </div>
+    </div>
+  </GDialog>
+
   <Loader v-if="isLoading" />
 </template>
 
 <style lang="scss" scoped>
 @import "@/assets/styles/_variables.scss";
+
+.admin-users__item-head_actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.import-modal__tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid $sc2;
+  margin-bottom: 8px;
+
+  button {
+    padding: 8px 14px;
+    border: none;
+    background: transparent;
+    color: $sc2;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    font-size: 16px;
+
+    &.active {
+      color: $pr1;
+      border-bottom-color: $pr1;
+    }
+  }
+}
+
+.import-modal__url {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  &-input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid $sc2;
+    border-radius: 6px;
+    font-size: 14px;
+
+    &::placeholder {
+      color: $sc6;
+    }
+
+    &:focus {
+      outline: none;
+      border-color: $pr1;
+    }
+  }
+}
+
+.import-modal {
+  background: #fff;
+  border-radius: 10px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__title {
+    margin: 0;
+    font-size: 22px;
+  }
+
+  &__hint {
+    margin: 0;
+    color: $sc2;
+  }
+
+  &__file {
+    padding: 6px 0;
+  }
+
+  &__error {
+    margin: 0;
+    color: #dc3545;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }
+
+  &__errors {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 8px;
+
+    th, td {
+      border: 1px solid $sc2;
+      padding: 6px 8px;
+      text-align: left;
+      font-size: 14px;
+    }
+  }
+
+  &__form, &__result {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+}
 
 .mail-moves {
   svg {

--- a/src/views/StudentProfile.vue
+++ b/src/views/StudentProfile.vue
@@ -40,11 +40,15 @@
       </p>
       <p class="profile__right-item">
         Научный руководитель
-        <span>{{ userMap[student.supervisor] || "-" }}</span>
+        <span>{{ student.supervisorFullName || "—" }}</span>
+      </p>
+      <p class="profile__right-item">
+        Тема курсовой
+        <span>{{ student.courseWorkTopic || "—" }}</span>
       </p>
       <p class="profile__right-item">
         Тема ВКР
-        <span>{{ student.courseJob || "-" }}</span>
+        <span>{{ student.thesisTopic || "—" }}</span>
       </p>
       <p v-if="student.departmentInfo" class="profile__right-item">
         Кафедра

--- a/src/views/StudentsListTable.vue
+++ b/src/views/StudentsListTable.vue
@@ -154,27 +154,10 @@
               </template>
             </td>
 
-            <td @click="startEdit(student)">
-              <template v-if="editedStudentId === student.id">
-                <select
-                  v-model="student.supervisor"
-                  @blur="stopEdit(student)"
-                  @change="stopEdit(student)"
-                >
-                  <option
-                    v-for="user in userList"
-                    :key="user.id"
-                    :value="user.id"
-                  >
-                    {{ user.fullName }}
-                  </option>
-                </select>
-              </template>
-              <template v-else>
-                <span :title="student.supervisorName">{{
-                  student.supervisorName
-                }}</span>
-              </template>
+            <td>
+              <span :title="student.supervisorFullName || '—'">
+                {{ student.supervisorFullName || "—" }}
+              </span>
             </td>
 
             <td>
@@ -322,7 +305,6 @@ import { ref, computed, onMounted } from "vue";
 import axios from "axios";
 import { GDialog } from "gitart-vue-dialog/dist/index";
 
-const userList = ref([]);
 const studentsList = ref([]);
 const years = Array.from({ length: 101 }, (_, index) => 2027 - index);
 const hiddenStudentsStorageKey = "adminHiddenStudents";
@@ -368,7 +350,7 @@ const columns = [
   { key: "group", label: "Группа" },
   { key: "startYear", label: "Год нач." },
   { key: "endYear", label: "Год оконч." },
-  { key: "supervisorName", label: "Руководитель" },
+  { key: "supervisorFullName", label: "Руководитель" },
   { key: "login", label: "Логин" },
   { key: "deleteCol", label: "" },
 ];
@@ -379,25 +361,8 @@ const sortKey = ref("");
 const sortOrder = ref("asc");
 
 onMounted(() => {
-  getUsers();
   getStudents();
 });
-
-const getUsers = async () => {
-  await axios.get("employees").then((userData) => {
-    userList.value = userData.data
-      .filter((user) => user.isActive !== false)
-      .map((user) => ({
-        id: user.id,
-        fullName: `${user.lastName} ${user.firstName.charAt(
-          0,
-        )}.${user.patronymic.charAt(0)}.`,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        patronymic: user.patronymic,
-      }));
-  });
-};
 
 const getStudents = async () => {
   await axios.get("students").then((userData) => {
@@ -430,20 +395,12 @@ function stopEdit(student) {
         "group",
         "startYear",
         "endYear",
-        "supervisor",
         "login",
         "password",
       ].includes(key)
     ) {
       changedFields[key] = student[key];
     }
-  }
-
-  const supervisor = userList.value.find(
-    (user) => user.id === student.supervisor,
-  );
-  if (supervisor) {
-    student.supervisorName = `${supervisor.lastName} ${supervisor.firstName[0]}.${supervisor.patronymic[0]}.`;
   }
 
   if (Object.keys(changedFields).length) {
@@ -460,20 +417,8 @@ async function editStudent(id, body) {
   });
 }
 
-const studentsWithSupervisorName = computed(() => {
-  return studentsList.value.map((student) => {
-    const supervisor = userList.value.find(
-      (user) => user.id === student.supervisor,
-    );
-    return {
-      ...student,
-      supervisorName: supervisor ? supervisor.fullName : "—",
-    };
-  });
-});
-
 const sortedData = computed(() => {
-  const data = [...studentsWithSupervisorName.value];
+  const data = [...studentsList.value];
   if (!sortKey.value) return data;
   return data.sort((a, b) => {
     const aVal = a[sortKey.value];


### PR DESCRIPTION
### Импорт студентов и тем в админке (`Admin.vue`)
  В табе «Студенты» — три кнопки: **«Импорт студентов»**, **«Импорт тем»**, **«Добавить»**. Каждая из двух кнопок импорта открывает диалог с двумя вкладками:
  - **«Файл .xlsx/.csv»** — `multipart/form-data` на `students/import` или `students/topics/import`.                                                                                                     
  - **«Ссылка Google Sheets»** — JSON `{url}` на `students/import/google-sheet` или `students/topics/import/google-sheet`.                                                                               
                                                                                                                                                                                                         
  После импорта показывается отчёт «Создано / Обновлено / Пропущено / Ошибок» с таблицей ошибок. После «Закрыть» страница перезагружается.                                                               
                                                         
  UI-подсказки:                                                                                                                                                                                          
  - Для импорта студентов: «Загрузите выгрузку участников курса из Moodle. Строки без группы будут пропущены».
  - Для импорта тем: «Перед импортом убедитесь, что студенты уже добавлены в систему» и «Повторный импорт перезаписывает темы целиком».                                                                  
  - Для Google Sheets: «Таблица должна быть открыта по ссылке (Файл → Поделиться → Доступ по ссылке: Просмотр)».                                                                                         
                                                                                                                                                                                                         
  ### AD-bind в логин-форме (`Header.vue`)                                                                                                                                                               
  Двухэтапный вход для студентов первого раза:                                                                                                                                                           
  1. AD-логин + AD-пароль → `POST /api/authenticate`.                                                                                                                                                    
  2. При ответе `{bindRequired: true}` модалка показывает поле «Логин в Moodle» (credentials остаются в state).                                                                                          
  3. Moodle-логин → `POST /api/auth/student/bind` → JWT.                                                                                                                                                 
                                                                                                                                                                                                         
  Кнопка «Назад» возвращает к шагу 1. Студенты не из кафедры получают 403. 2FA-флоу взаимоисключим с bind.                                                                                               
                                                                                                                                                                                                         
  ### Темы и руководитель в профиле и таблице                                                                                                                                                            
  - `StudentProfile.vue` показывает «Научный руководитель» (`supervisorFullName`), «Тема курсовой» (`courseWorkTopic`), «Тема ВКР» (`thesisTopic`) — из расширенного `StudentResponse`. Старые поля
  `courseJob` и `supervisor` больше не читаются.                                                                                                                                                         
  - `StudentsListTable.vue`: колонка «Руководитель» — read-only через `supervisorFullName`. Убран inline-edit, computed `studentsWithSupervisorName`, неиспользуемые `getUsers()` и `userList`.
                                                                                                                                                                                                         